### PR TITLE
Fix initial status

### DIFF
--- a/lib/src/expandable_sliver_list.dart
+++ b/lib/src/expandable_sliver_list.dart
@@ -20,10 +20,6 @@ class ExpandableSliverList<T> extends StatefulWidget {
   /// Builder function that will be called on every item
   final ExpandableItemBuilder<T> builder;
 
-  /// If set to true, this list will start collapsed, and will need to be
-  /// expanded before any of the contents can be shown.
-  final bool startCollapsed;
-
   /// The controller that will operate this animated list
   final ExpandableSliverListController<T> controller;
 
@@ -39,7 +35,6 @@ class ExpandableSliverList<T> extends StatefulWidget {
     required Iterable<T> initialItems,
     required this.builder,
     required this.controller,
-    this.startCollapsed = false,
     this.duration = kDefaultDuration,
     this.expandOnInitialInsertion = false,
   })  : initialItems = List<T>.from(initialItems),
@@ -55,18 +50,7 @@ class _ExpandableSliverListState<T> extends State<ExpandableSliverList<T>> {
   void initState() {
     super.initState();
 
-    ExpandableSliverListStatus initialStatus = widget.startCollapsed
-        ? ExpandableSliverListStatus.collapsed
-        : ExpandableSliverListStatus.expanded;
-
-    if (widget.startCollapsed) {
-      initialStatus = ExpandableSliverListStatus.collapsed;
-    } else {
-      initialStatus = ExpandableSliverListStatus.expanded;
-    }
-
     widget.controller.init(
-      initialState: initialStatus,
       items: widget.initialItems,
       duration: widget.duration,
       builder: widget.builder,

--- a/lib/src/expandable_sliver_list_controller.dart
+++ b/lib/src/expandable_sliver_list_controller.dart
@@ -38,19 +38,19 @@ class ExpandableSliverListController<T>
   bool _initialized = false;
 
   /// Controller that'll be used to switch the list between collapsed and
-  /// expanded
-  ExpandableSliverListController()
-      : super(ExpandableSliverListStatus.collapsed);
+  /// expanded.
+  ExpandableSliverListController(
+      {ExpandableSliverListStatus initialStatus =
+          ExpandableSliverListStatus.expanded})
+      : super(initialStatus);
 
   /// Initializer to be called by the expandable list this is assigned to
   void init({
-    required ExpandableSliverListStatus initialState,
     required List<T> items,
     required ExpandableItemBuilder<T> builder,
     required Duration duration,
     bool expandOnInitialInsertion = false,
   }) {
-    value = initialState;
     _items = items;
     _builder = builder;
     _duration = duration;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/test/expandable_sliver_list_test.dart
+++ b/test/expandable_sliver_list_test.dart
@@ -121,7 +121,6 @@ void main() {
                 ExpandableSliverList<int>(
                   initialItems: _items,
                   controller: controller,
-                  startCollapsed: true,
                   builder: (context, item, index) {
                     return ListTile(
                       title: Text(item.toString()),
@@ -179,7 +178,6 @@ void main() {
                   initialItems: _items,
                   controller: controller,
                   duration: const Duration(seconds: 1),
-                  startCollapsed: true,
                   expandOnInitialInsertion: true,
                   builder: (context, item, index) {
                     return ListTile(
@@ -277,7 +275,6 @@ void main() {
 
         // start off expanded
         expandableSliverListController.init(
-          initialState: ExpandableSliverListStatus.expanded,
           items: [],
           builder: (BuildContext context, item, index) {
             return Container();
@@ -327,7 +324,6 @@ void main() {
             ExpandableSliverListController<int>();
 
         controller.init(
-            initialState: ExpandableSliverListStatus.expanded,
             items: [],
             builder: (a, b, c) => Container(),
             duration: Duration(seconds: 0));
@@ -375,8 +371,15 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   final List<String> _items = ["Hello", "This", "List", "Expands"];
 
-  final ExpandableSliverListController<String> _expandableSliverListController =
-      ExpandableSliverListController();
+  late ExpandableSliverListController<String> _expandableSliverListController;
+
+  @override
+  void initState() {
+    _expandableSliverListController =
+        ExpandableSliverListController(initialStatus: widget.startCollapsed ? ExpandableSliverListStatus.collapsed : ExpandableSliverListStatus.expanded);
+    super.initState();
+
+  }
 
   void _toggleList() {
     if (_expandableSliverListController.isCollapsed()) {
@@ -393,7 +396,6 @@ class _MyHomePageState extends State<MyHomePage> {
         slivers: [
           ExpandableSliverList<String>(
             initialItems: _items,
-            startCollapsed: widget.startCollapsed,
             controller: _expandableSliverListController,
             duration: const Duration(seconds: 1),
             builder: (context, item, index) {


### PR DESCRIPTION
If the list was initialized as expanded, then the controller would initially report it as collapsed. 

This PR moves the initialStatus as an argument of the controller itself, much like other controllers (TextEditingController takes the text as argument) do it.

This is a breaking change though